### PR TITLE
Seems like a8718f3 broke hostname for RHEL5;

### DIFF
--- a/library/system/hostname
+++ b/library/system/hostname
@@ -221,6 +221,11 @@ class RedHatStrategy(GenericStrategy):
             self.module.fail_json(msg="failed to update hostname: %s" %
                 str(err))
 
+class RedHat5Hostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Redhat'
+    strategy_class = RedHatStrategy
+    
 class RedHatHostname(Hostname):
     platform = 'Linux'
     distribution = 'Red hat enterprise linux server'


### PR DESCRIPTION
Seems like a8718f3 broke functionality on RHEL5. 
Please see my change proposal.

This time I managed to test on 5.10 and 6.4
